### PR TITLE
Fix local url used to load out.fgb

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -55,7 +55,7 @@ pub async fn get_negative_space(
 
     let bbox = widths::bbox(&input_route, project_away_meters);
     timer.step("Downloading nearby polygons");
-    let url = "http://localhost:5173/out.fgb";
+    let url = "http://localhost:5173/will-it-fit/out.fgb";
     let polygons = read_nearby_polygons(bbox, url).await.map_err(err_to_js)?;
 
     let mut out = Features {


### PR DESCRIPTION
I needed this change to be able to run the web app locally. I don't know if it is a bug, or if there is some trick with npm that I could have used, which would allow the file to be served from the expected URL.
