### PR TITLE
Show cases where road's rating changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target
 node_modules
 web/public/
 data_prep/inspire
+data_prep/local_inputs
 pavement_parking/inputs
 pavement_parking/web/public/summaries.geojson
 pavement_parking/web/public/pavements.geojson

--- a/pavement_parking/src/main.rs
+++ b/pavement_parking/src/main.rs
@@ -128,13 +128,11 @@ fn process_feature(
     let average_rating_exc_pavements = rating(&class, average)?;
     let minimum_rating = rating(&class, minimum)?;
 
-    let average_rating;
-    
-    if average_rating_inc_pavements == average_rating_exc_pavements{
-        average_rating = "no-change";
+    let average_rating = if average_rating_inc_pavements == average_rating_exc_pavements {
+        "no_change"
     } else {
-        average_rating = average_rating_exc_pavements;
-    }
+        average_rating_exc_pavements
+    };
     
 
     // Find all matching boundaries

--- a/pavement_parking/src/main.rs
+++ b/pavement_parking/src/main.rs
@@ -93,19 +93,19 @@ fn process_feature(
     boundaries: &mut Boundaries,
     writer: &mut FeatureWriter<BufWriter<File>>,
 ) -> Result<()> {
-    let Some(average) = input.field_as_double_by_name("roadwidth_average")? else {
+    let Some(road_average) = input.field_as_double_by_name("roadwidth_average")? else {
         return Ok(());
     };
-    let Some(minimum) = input.field_as_double_by_name("roadwidth_minimum")? else {
+    let Some(road_minimum) = input.field_as_double_by_name("roadwidth_minimum")? else {
         return Ok(());
     };
     let Some(class) = input.field_as_string_by_name("roadclassification")? else {
         return Ok(());
     };
 
-    // Assume that where there are pavements on both side of the road, then this value is the
+    // Assume that where there are pavements on both sides of the road, then this value is the
     // sum of both pavements. If there is only one pavement, then this value is the width of that.
-    let Some(pavement_average_width) =
+    let Some(pavement_average) =
         input.field_as_double_by_name("presenceofpavement_averagewidth_m")?
     else {
         return Ok(());
@@ -126,9 +126,9 @@ fn process_feature(
         x => bail!("Unknown directionality {x}"),
     };
 
-    let average_rating_inc_pavements = rating(&class, average + pavement_average_width)?;
-    let average_rating_exc_pavements = rating(&class, average)?;
-    let minimum_rating = rating(&class, minimum)?;
+    let average_rating_inc_pavements = rating(&class, road_average + pavement_average)?;
+    let average_rating_exc_pavements = rating(&class, road_average)?;
+    let minimum_rating = rating(&class, road_minimum)?;
 
     let rating_change = if average_rating_inc_pavements == average_rating_exc_pavements {
         "no_change"
@@ -160,8 +160,8 @@ fn process_feature(
 
     // Include the road in the output
     let mut output_line = geojson::Feature::from(geojson::Value::from(&geom));
-    output_line.set_property("average_width", average);
-    output_line.set_property("minimum_width", minimum);
+    output_line.set_property("average_width", road_average);
+    output_line.set_property("minimum_width", road_minimum);
     output_line.set_property("pavement_average_width", pavement_average_width);
     output_line.set_property("average_rating", average_rating_exc_pavements);
     output_line.set_property("average_rating_inc_pavements", average_rating_inc_pavements);

--- a/pavement_parking/src/main.rs
+++ b/pavement_parking/src/main.rs
@@ -128,12 +128,11 @@ fn process_feature(
     let average_rating_exc_pavements = rating(&class, average)?;
     let minimum_rating = rating(&class, minimum)?;
 
-    let average_rating = if average_rating_inc_pavements == average_rating_exc_pavements {
+    let rating_change = if average_rating_inc_pavements == average_rating_exc_pavements {
         "no_change"
     } else {
         average_rating_exc_pavements
     };
-    
 
     // Find all matching boundaries
     for obj in boundaries
@@ -143,12 +142,12 @@ fn process_feature(
         // TODO Or even just intersects, to handle boundaries?
         if obj.geom().contains(&geom) {
             let count = boundaries.counts.get_mut(&obj.data).unwrap();
-            // TODO Use average_rating for now
-            if average_rating == "red" {
+            // TODO Use average_rating_exc_pavements for now
+            if average_rating_exc_pavements == "red" {
                 count[0] += 1;
-            } else if average_rating == "amber" {
+            } else if average_rating_exc_pavements == "amber" {
                 count[1] += 1;
-            } else if average_rating == "green" {
+            } else if average_rating_exc_pavements == "green" {
                 count[2] += 1;
             } else {
                 // No change in rating
@@ -162,8 +161,10 @@ fn process_feature(
     output_line.set_property("average_width", average);
     output_line.set_property("minimum_width", minimum);
     output_line.set_property("pavement_average_width", pavement_average_width);
-    output_line.set_property("average_rating", average_rating);
+    output_line.set_property("average_rating", average_rating_exc_pavements);
+    output_line.set_property("average_rating_inc_pavements", average_rating_inc_pavements);
     output_line.set_property("minimum_rating", minimum_rating);
+    output_line.set_property("rating_change", rating_change);
     output_line.set_property("class", class);
     output_line.set_property("direction", direction);
     writer.write_feature(&output_line)?;

--- a/pavement_parking/src/main.rs
+++ b/pavement_parking/src/main.rs
@@ -105,7 +105,9 @@ fn process_feature(
 
     // Assume that where there are pavements on both side of the road, then this value is the
     // sum of both pavements. If there is only one pavement, then this value is the width of that.
-    let Some(pavement_average_width) = input.field_as_double_by_name("presenceofpavement_averagewidth_m")? else {
+    let Some(pavement_average_width) =
+        input.field_as_double_by_name("presenceofpavement_averagewidth_m")?
+    else {
         return Ok(());
     };
 

--- a/pavement_parking/web/src/PavementLayers.svelte
+++ b/pavement_parking/web/src/PavementLayers.svelte
@@ -64,7 +64,8 @@
         {#if data.properties.rating_change == "no_change"}
           Rating is not changed by excluding pavement parking
         {:else}
-          Change: Rating including pavement parking is {data.properties.average_rating_inc_pavements}
+          Change: Rating including pavement parking is {data.properties
+            .average_rating_inc_pavements}
         {/if}
       </p>
     {/if}

--- a/pavement_parking/web/src/PavementLayers.svelte
+++ b/pavement_parking/web/src/PavementLayers.svelte
@@ -60,6 +60,13 @@
         Minimum width {data.properties.minimum_width}, rating {data.properties
           .minimum_rating}
       </p>
+      <p>
+        {#if data.properties.rating_change == "no_change"}
+          Rating is not changed by excluding pavement parking
+        {:else}
+          Change: Rating including pavement parking is {data.properties.average_rating_inc_pavements}
+        {/if}
+      </p>
     {/if}
   </Popup>
 </LineLayer>

--- a/pavement_parking/web/src/PavementLayers.svelte
+++ b/pavement_parking/web/src/PavementLayers.svelte
@@ -53,13 +53,14 @@
       <h1>{data.properties.class} street</h1>
       <p>Direction: {data.properties.direction}</p>
       <p>
-        Average width {data.properties.average_width}, rating {data.properties
-          .average_rating}
+        Average road width {data.properties.average_width}, rating {data
+          .properties.average_rating}
       </p>
       <p>
-        Minimum width {data.properties.minimum_width}, rating {data.properties
-          .minimum_rating}
+        Minimum road width {data.properties.minimum_width}, rating {data
+          .properties.minimum_rating}
       </p>
+      <p>Pavement average width: {data.properties.pavement_average_width}</p>
       <p>
         {#if data.properties.rating_change == "no_change"}
           Rating is not changed by excluding pavement parking

--- a/pavement_parking/web/src/StreetFilters.svelte
+++ b/pavement_parking/web/src/StreetFilters.svelte
@@ -47,7 +47,6 @@
     <input type="checkbox" bind:checked={filters.showRatings.no_change} />
     No Change
   </label>
-
 </fieldset>
 
 <fieldset>

--- a/pavement_parking/web/src/StreetFilters.svelte
+++ b/pavement_parking/web/src/StreetFilters.svelte
@@ -17,11 +17,15 @@
   <legend>Color ratings using:</legend>
   <label>
     <input type="radio" value="average_rating" bind:group={filters.useRating} />
-    average width
+    average width (all roads)
+  </label>
+  <label>
+    <input type="radio" value="rating_change" bind:group={filters.useRating} />
+    average width (changes only)
   </label>
   <label>
     <input type="radio" value="minimum_rating" bind:group={filters.useRating} />
-    minimum width
+    minimum width (all roads)
   </label>
 </fieldset>
 

--- a/pavement_parking/web/src/StreetFilters.svelte
+++ b/pavement_parking/web/src/StreetFilters.svelte
@@ -39,6 +39,11 @@
     <input type="checkbox" bind:checked={filters.showRatings.red} />
     Red
   </label>
+  <label style:color={colors.black}>
+    <input type="checkbox" bind:checked={filters.showRatings.no_change} />
+    No Change
+  </label>
+
 </fieldset>
 
 <fieldset>

--- a/pavement_parking/web/src/StreetFilters.svelte
+++ b/pavement_parking/web/src/StreetFilters.svelte
@@ -43,7 +43,8 @@
     <input type="checkbox" bind:checked={filters.showRatings.red} />
     Red
   </label>
-  <label style:color={colors.black}>
+  <label>
+    <!-- The color doesn't show up -->
     <input type="checkbox" bind:checked={filters.showRatings.no_change} />
     No Change
   </label>

--- a/pavement_parking/web/src/types.ts
+++ b/pavement_parking/web/src/types.ts
@@ -4,6 +4,7 @@ export interface Filters {
     green: boolean;
     amber: boolean;
     red: boolean;
+    no_change: boolean;
   };
   showClasses: {
     "A Road": boolean;
@@ -25,6 +26,7 @@ export const defaultFilters: Filters = {
     green: true,
     amber: true,
     red: true,
+    no_change: true,
   },
   showClasses: {
     "A Road": true,
@@ -44,4 +46,5 @@ export const colors = {
   green: "#006853",
   amber: "#ffd833",
   red: "#b73d25",
+  black: "#000000",
 };

--- a/pavement_parking/web/src/types.ts
+++ b/pavement_parking/web/src/types.ts
@@ -1,5 +1,5 @@
 export interface Filters {
-  useRating: "average_rating" | "minimum_rating";
+  useRating: "average_rating" | "rating_change" | "minimum_rating";
   showRatings: {
     green: boolean;
     amber: boolean;


### PR DESCRIPTION
So far, this only updates the rating assigned to roads to give "no-change" where appropriate and the rating excluding pavement parking.

"No change" roads now show black in the Web UI.

I'd still like to update this so that the user can switch between showing the change in rating vs the absolute rating.
Also, there isn't a meaningful option for showing the change in rating for the minimum widths.
